### PR TITLE
fix the base url in api_service.dart

### DIFF
--- a/lib/repositories/api_service.dart
+++ b/lib/repositories/api_service.dart
@@ -2,7 +2,7 @@ import 'package:dio/dio.dart';
 
 class ApiService {
   final Dio _dio = Dio(BaseOptions(
-    baseUrl: 'http://localhost/api',
+    baseUrl: 'http://127.0.0.1:8000/api',
   ));
 
 


### PR DESCRIPTION
كان في خطأ بسيط في Base_Url في api_service.dart
والان انشاء الحساب في DB يعمل كما هو متوقع منه:
![image](https://github.com/user-attachments/assets/35a4cdaf-93b6-4a0c-8ba9-c5e00129f9f3)


ولم أصلح باقي الاخطاء فهناك مشكله لم أحلها... وهي عند الاتمام من انشاء الحساب يجب التأكد اذا كان status code = 201 فهنا يجب ان ينتقل المستخدم الى صفحه الhome او الى صفحه تسجيل الدخول بشكل تلقائي